### PR TITLE
return empty array when user enters no query ids

### DIFF
--- a/middleware/userMiddleware.js
+++ b/middleware/userMiddleware.js
@@ -65,7 +65,7 @@ userMiddleware.getUsers = function (req, res) {
     var queryUsers = req.query.users;
     // you have no contacts
     if (queryUsers == null || queryUsers == 'undefined') {
-      res.status(200);
+      res.status(200).json([]);
     } else {
       var isArray = queryUsers.constructor === Array;
       res.status(200).json(getQueriedUsers(queryUsers, snapshot, isArray));


### PR DESCRIPTION
Squashed commits:
[e13d563] empty array json data
[7c43943] return null when no query users are entered